### PR TITLE
Readme: Added fix for csrf cookie not being set

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,19 @@ class MyLoginForm extends React.Component {
 }
 ```
 
+## CSRF Cookie and React
+
+Because react renders elements dynamically, Django might not set a CSRF token cookie if you render a form using react.
+This is described in [the Django docs](https://docs.djangoproject.com/en/1.11/ref/csrf/):
+> If your view is not rendering a template containing the csrf_token template tag, Django might not set the CSRF token cookie. This is common in cases where forms are dynamically added to the page. To address this case, Django provides a view decorator which forces setting of the cookie: ensure_csrf_cookie().
+
+To fix this problem add the decorator mentioned above to your views:
+```python
+
+from django.views.decorators.csrf import ensure_csrf_cookie
+
+@ensure_csrf_cookie
+def register_view(request):
+    // ...
+
+```


### PR DESCRIPTION
Added a solution for when cookies aren't being set when creating form with react.
This is important because users may think this is a problem with this module, when it isn't.