### PR TITLE
Allow React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "6.x.x",
-    "react": "^15.3.2",
+    "react": "^15.3.2 || ^16.0.0",
     "react-cookie": "^0.4.8",
     "react-dom-factories": "^1.0.1"
   },


### PR DESCRIPTION
Hi, thanks for this library. We're using React 16, and it would be nice if this wouldn't pull in React 15 as a dependency :) Moving React to [peer dependencies](https://docs.npmjs.com/files/package.json#peerdependencies) might also be a good idea.